### PR TITLE
add wrapping Client and Server into Agents holding nif's ref in state

### DIFF
--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -15,39 +15,65 @@ defmodule ExLibSRT.Client do
   * `t:srt_client_error/0`
   """
 
-  @type t :: reference()
+  use Agent
+
+  @type t :: pid()
 
   @type srt_client_started :: :srt_client_started
   @type srt_client_disconnected :: :srt_client_started
   @type srt_client_error :: {:srt_client_error, reason :: String.t()}
 
   @doc """
-  Starts a new SRT connection to the target address and port.
+  Starts a new SRT connection to the target address and port and link to the current process.
+  """
+  @spec start_link(address :: String.t(), port :: non_neg_integer(), stream_id :: String.t()) ::
+          {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
+  def start_link(address, port, stream_id) do
+    case ExLibSRT.Native.start_client(address, port, stream_id) do
+      {:ok, client_ref} ->
+        Agent.start_link(fn -> client_ref end, name: {:global, client_ref})
+
+      {:error, reason, error_code} ->
+        {:error, reason, error_code}
+    end
+  end
+
+  @doc """
+  Starts a new SRT connection to the target address and port outside the supervision tree.
   """
   @spec start(address :: String.t(), port :: non_neg_integer(), stream_id :: String.t()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start(address, port, stream_id) do
-    ExLibSRT.Native.start_client(address, port, stream_id)
+    case ExLibSRT.Native.start_client(address, port, stream_id) do
+      {:ok, client_ref} ->
+        Agent.start(fn -> client_ref end, name: {:global, client_ref})
+
+      {:error, reason, error_code} ->
+        {:error, reason, error_code}
+    end
   end
 
   @doc """
   Stops the active client connection.
   """
   @spec stop(t()) :: :ok
-  def stop(client) do
-    ExLibSRT.Native.stop_client(client)
+  def stop(agent) do
+    client_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.stop_client(client_ref)
+    Agent.stop(agent)
   end
 
   @doc """
   Sends data through the client connection.
   """
   @spec send_data(binary(), t()) :: :ok | {:error, :payload_too_large | (reason :: String.t())}
-  def send_data(payload, client)
+  def send_data(payload, agent)
 
-  def send_data(payload, _client) when byte_size(payload) > 1316, do: {:error, :payload_too_large}
+  def send_data(payload, _agent) when byte_size(payload) > 1316, do: {:error, :payload_too_large}
 
-  def send_data(payload, client) do
-    ExLibSRT.Native.send_client_data(payload, client)
+  def send_data(payload, agent) do
+    client_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.send_client_data(payload, client_ref)
   end
 
   @doc """
@@ -55,6 +81,8 @@ defmodule ExLibSRT.Client do
   """
   @spec read_socket_stats(t()) ::
           {:ok, ExLibSRT.SocketStats.t()} | {:error, reason :: String.t()}
-  def read_socket_stats(client),
-    do: ExLibSRT.Native.read_client_socket_stats(client)
+  def read_socket_stats(agent) do
+    client_ref = Agent.get(agent, & &1)
+    ExLibSRT.Native.read_client_socket_stats(client_ref)
+  end
 end

--- a/lib/ex_libsrt/client.ex
+++ b/lib/ex_libsrt/client.ex
@@ -24,14 +24,14 @@ defmodule ExLibSRT.Client do
   @type srt_client_error :: {:srt_client_error, reason :: String.t()}
 
   @doc """
-  Starts a new SRT connection to the target address and port and link to the current process.
+  Starts a new SRT connection to the target address and port and links to the current process.
   """
   @spec start_link(address :: String.t(), port :: non_neg_integer(), stream_id :: String.t()) ::
           {:ok, t()} | {:error, reason :: String.t(), error_code :: integer()}
   def start_link(address, port, stream_id) do
     case ExLibSRT.Native.start_client(address, port, stream_id) do
       {:ok, client_ref} ->
-        Agent.start_link(fn -> client_ref end, name: {:global, client_ref})
+        Agent.start_link(fn -> client_ref end)
 
       {:error, reason, error_code} ->
         {:error, reason, error_code}

--- a/lib/ex_libsrt/server.ex
+++ b/lib/ex_libsrt/server.ex
@@ -60,7 +60,7 @@ defmodule ExLibSRT.Server do
   def start_link(address, port) do
     case ExLibSRT.Native.start_server(address, port) do
       {:ok, server_ref} ->
-        Agent.start_link(fn -> server_ref end, name: {:global, server_ref})
+        Agent.start_link(fn -> server_ref end)
 
       {:error, reason, error_code} ->
         {:error, reason, error_code}


### PR DESCRIPTION
Add wrapping `ExLibSRT.Client` and `ExLibSRT.Server` in `Agent` to prevent loosing reference to nifs.